### PR TITLE
Only update recently updated workflows

### DIFF
--- a/scripts/generate-catalog.py
+++ b/scripts/generate-catalog.py
@@ -117,6 +117,15 @@ def store_data():
         json.dump(skips, out, sort_keys=True, indent=2)
 
 
+def check_repo_exists(g, full_name):
+    try:
+        g.get_repo(full_name)
+        return True
+    except UnknownObjectException:
+        logging.info(f"Repo {full_name} has been deleted")
+        return False
+
+
 repo_search = g.search_repositories("snakemake workflow in:readme archived:false",
         sort="updated")
 
@@ -148,7 +157,13 @@ for i, repo in enumerate(repo_search):
     ):
         # keep old data, it hasn't changed
         logging.info("Remaining repos haven't changed, using old data.")
-        older_repos = [repo for repo in previous_repos.values() if repo["updated_at"] <= updated_at.timestamp()]
+        older_repos = [
+                old_repo for old_repo in previous_repos.values()
+                if (old_repo["updated_at"] <= updated_at.timestamp())
+                and call_rate_limit_aware(
+                    lambda: check_repo_exists(g, old_repo["full_name"])
+                    )
+                ]
         repos += older_repos
         break
     prev_skip = previous_skips.get(repo.full_name)

--- a/scripts/generate-catalog.py
+++ b/scripts/generate-catalog.py
@@ -126,8 +126,9 @@ def check_repo_exists(g, full_name):
         return False
 
 
-repo_search = g.search_repositories("snakemake workflow in:readme archived:false",
-        sort="updated")
+repo_search = g.search_repositories(
+    "snakemake workflow in:readme archived:false", sort="updated"
+)
 
 for i, repo in enumerate(repo_search):
     if i % 10 == 0:
@@ -158,12 +159,13 @@ for i, repo in enumerate(repo_search):
         # keep old data, it hasn't changed
         logging.info("Remaining repos haven't changed, using old data.")
         older_repos = [
-                old_repo for old_repo in previous_repos.values()
-                if (old_repo["updated_at"] <= updated_at.timestamp())
-                and call_rate_limit_aware(
-                    lambda: check_repo_exists(g, old_repo["full_name"])
-                    )
-                ]
+            old_repo
+            for old_repo in previous_repos.values()
+            if (old_repo["updated_at"] <= updated_at.timestamp())
+            and call_rate_limit_aware(
+                lambda: check_repo_exists(g, old_repo["full_name"])
+            )
+        ]
         repos += older_repos
         break
     prev_skip = previous_skips.get(repo.full_name)

--- a/scripts/generate-catalog.py
+++ b/scripts/generate-catalog.py
@@ -148,7 +148,7 @@ for i, repo in enumerate(repo_search):
     ):
         # keep old data, it hasn't changed
         logging.info("Remaining repos haven't changed, using old data.")
-        older_repos = [repo for repo in previous_repos.values() if repo["updated_at"] =< updated_at.timestamp()]
+        older_repos = [repo for repo in previous_repos.values() if repo["updated_at"] <= updated_at.timestamp()]
         repos += older_repos
         break
     prev_skip = previous_skips.get(repo.full_name)

--- a/scripts/generate-catalog.py
+++ b/scripts/generate-catalog.py
@@ -117,7 +117,8 @@ def store_data():
         json.dump(skips, out, sort_keys=True, indent=2)
 
 
-repo_search = g.search_repositories("snakemake workflow in:readme archived:false")
+repo_search = g.search_repositories("snakemake workflow in:readme archived:false",
+        sort="updated")
 
 for i, repo in enumerate(repo_search):
     if i % 10 == 0:
@@ -146,9 +147,10 @@ for i, repo in enumerate(repo_search):
         and prev["updated_at"] == updated_at.timestamp()
     ):
         # keep old data, it hasn't changed
-        logging.info("Repo hasn't changed, using old data.")
-        repos.append(prev)
-        continue
+        logging.info("Remaining repos haven't changed, using old data.")
+        older_repos = [repo for repo in previous_repos.values() if repo["updated_at"] < updated_at.timestamp()]
+        repos += older_repos
+        break
     prev_skip = previous_skips.get(repo.full_name)
     if prev_skip is not None and prev_skip["updated_at"] == updated_at.timestamp():
         # keep old data, it hasn't changed

--- a/scripts/generate-catalog.py
+++ b/scripts/generate-catalog.py
@@ -148,7 +148,7 @@ for i, repo in enumerate(repo_search):
     ):
         # keep old data, it hasn't changed
         logging.info("Remaining repos haven't changed, using old data.")
-        older_repos = [repo for repo in previous_repos.values() if repo["updated_at"] < updated_at.timestamp()]
+        older_repos = [repo for repo in previous_repos.values() if repo["updated_at"] =< updated_at.timestamp()]
         repos += older_repos
         break
     prev_skip = previous_skips.get(repo.full_name)


### PR DESCRIPTION
This PR tries to resolve #3 by changing how `data.js` is updated. The idea is to sort the searched repositories by when they were last updated, and only update repos that have been changed since the previous update. This should make updates more efficient. A problem with the current state of this PR is that deleted repositories do not get removed, but I'm not sure how pressing this issue is. 