### PR TITLE
Check Snakefile and rule file endings prior to download

### DIFF
--- a/scripts/generate-catalog.py
+++ b/scripts/generate-catalog.py
@@ -206,9 +206,7 @@ for i, repo in enumerate(repo_search):
         continue
 
     if check_file_exists(repo, rules):
-        rule_contents = call_rate_limit_aware(
-                lambda: repo.get_contents(rules)
-                )
+        rule_contents = call_rate_limit_aware(lambda: repo.get_contents(rules))
         if not any(rule_file.name.endswith(".smk") for rule_file in rule_contents):
             log_skip("rule modules are not using .smk extension")
             register_skip(repo)

--- a/scripts/generate-catalog.py
+++ b/scripts/generate-catalog.py
@@ -108,6 +108,16 @@ def call_rate_limit_aware(func):
             rate_limit_wait()
 
 
+def call_rate_limit_aware_decorator(func):
+    def inner(*args, **kwargs):
+        while True:
+            try:
+                return func(*args, **kwargs)
+            except RateLimitExceededException:
+                rate_limit_wait()
+    return inner
+
+
 def store_data():
     repos.sort(key=lambda repo: repo["stargazers_count"])
 
@@ -126,6 +136,7 @@ def check_repo_exists(g, full_name):
         return False
 
 
+@call_rate_limit_aware_decorator
 def check_file_exists(repo, file_name):
     try:
         repo.get_contents(file_name)

--- a/scripts/generate-catalog.py
+++ b/scripts/generate-catalog.py
@@ -115,6 +115,7 @@ def call_rate_limit_aware_decorator(func):
                 return func(*args, **kwargs)
             except RateLimitExceededException:
                 rate_limit_wait()
+
     return inner
 
 

--- a/scripts/generate-catalog.py
+++ b/scripts/generate-catalog.py
@@ -190,9 +190,9 @@ for i, repo in enumerate(repo_search):
         rules = "workflow/" + rules
 
     if not check_file_exists(repo, snakefile):
-            log_skip("of missing Snakefile")
-            register_skip(repo)
-            continue
+        log_skip("of missing Snakefile")
+        register_skip(repo)
+        continue
 
     if check_file_exists(repo, rules):
         rule_contents = repo.get_contents(rules)

--- a/scripts/generate-catalog.py
+++ b/scripts/generate-catalog.py
@@ -206,7 +206,9 @@ for i, repo in enumerate(repo_search):
         continue
 
     if check_file_exists(repo, rules):
-        rule_contents = repo.get_contents(rules)
+        rule_contents = call_rate_limit_aware(
+                lambda: repo.get_contents(rules)
+                )
         if not any(rule_file.name.endswith(".smk") for rule_file in rule_contents):
             log_skip("rule modules are not using .smk extension")
             register_skip(repo)

--- a/scripts/generate-catalog.py
+++ b/scripts/generate-catalog.py
@@ -128,6 +128,7 @@ def store_data():
         json.dump(skips, out, sort_keys=True, indent=2)
 
 
+@call_rate_limit_aware_decorator
 def check_repo_exists(g, full_name):
     try:
         g.get_repo(full_name)
@@ -182,9 +183,7 @@ for i, repo in enumerate(repo_search):
             old_repo
             for old_repo in previous_repos.values()
             if (old_repo["updated_at"] <= updated_at.timestamp())
-            and call_rate_limit_aware(
-                lambda: check_repo_exists(g, old_repo["full_name"])
-            )
+            and check_repo_exists(g, old_repo["full_name"])
         ]
         repos += older_repos
         break


### PR DESCRIPTION
This PR moves the checking of the Snakefile and rule files prior to downloading the repo. This avoids downloading repos that do not contain a Snakefile or rule files ending in `.smk`, and speeds up the updates.