### PR TITLE
fix: linting/formatting results in scrollable window, more cross refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # snakemake-workflow-catalog
 
 [![Generate catalog](https://github.com/snakemake/snakemake-workflow-catalog/actions/workflows/generate.yml/badge.svg)](https://github.com/snakemake/snakemake-workflow-catalog/actions/workflows/generate.yml)
-[![pages-build-deployment](https://github.com/snakemake/snakemake-workflow-catalog/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/snakemake/snakemake-workflow-catalog/actions/workflows/pages/pages-build-deployment)
+[![Deploy catalog](https://github.com/snakemake/snakemake-workflow-catalog/actions/workflows/deploy.yml/badge.svg)](https://github.com/snakemake/snakemake-workflow-catalog/actions/workflows/deploy.yml)
 ![GitHub last commit](https://img.shields.io/github/last-commit/snakemake/snakemake-workflow-catalog?label=latest%20update)
 ![GitHub Issues or Pull Requests](https://img.shields.io/github/issues/snakemake/snakemake-workflow-catalog)
 

--- a/source/_templates/all_standardized_workflows.md
+++ b/source/_templates/all_standardized_workflows.md
@@ -22,7 +22,7 @@ description: "all standardized workflows"
         {%- if repo[qc] == None -%}
             {bdg-success}`{{qc}}: passed`
         {%- else -%}
-            {bdg-danger}`{{qc}}: failed`
+            {bdg-ref-danger}`{{qc}}: failed <{{qc}}-{{ repo["full_name"] }}>`
         {%- endif -%}
     {% endfor %}{% raw %},{% endraw %}
     {{ repo["stargazers_count"] }}{% raw %},{% endraw %}

--- a/source/_templates/all_standardized_workflows.md
+++ b/source/_templates/all_standardized_workflows.md
@@ -22,7 +22,7 @@ description: "all standardized workflows"
         {%- if repo[qc] == None -%}
             {bdg-success}`{{qc}}: passed`
         {%- else -%}
-            {bdg-ref-danger}`{{qc}}: failed <{{qc}}-{{ repo["full_name"] }}>`
+            {bdg-ref-danger}`{{qc}}: failed <{{qc}}-{{ repo["full_name"]|slugify }}>`
         {%- endif -%}
     {% endfor %}{% raw %},{% endraw %}
     {{ repo["stargazers_count"] }}{% raw %},{% endraw %}

--- a/source/_templates/workflow_page.md
+++ b/source/_templates/workflow_page.md
@@ -32,15 +32,14 @@
 {% if wf["linting"] == None -%}
     {bdg-success}`linting: passed`
 {%- else -%}
-    {bdg-danger}`linting: failed`
+    {bdg-ref-danger}`linting: failed <linting-{{ wf["full_name"] }}>`
 {%- endif -%},
 **Formatting:**
 {% if wf["formatting"] == None -%}
     {bdg-success}`formatting: passed`
 {%- else -%}
-    {bdg-danger}`formatting: failed`
+    {bdg-ref-danger}`formatting: failed <formatting-{{ wf["full_name"] }}>`
 {%- endif %}
-
 
 ## Deployment
 
@@ -137,6 +136,7 @@ _The following section is imported from the workflow's `config/README.md`_.
 
 ## Linting and formatting
 
+(linting-{{ wf["full_name"] }})=
 ### Linting results
 
 {% if wf["linting"] == None %}
@@ -144,11 +144,19 @@ _The following section is imported from the workflow's `config/README.md`_.
 All tests passed!
 ```
 {%- else -%}
-```
+
+<div style="height: 400px; overflow-y: scroll; padding: 0px;">
+
+```{code-block}
+:linenos:
+
 {{ wf["linting"] }}
 ```
+</div >
+
 {% endif %}
 
+(formatting-{{ wf["full_name"] }})=
 ### Formatting results
 
 {% if wf["formatting"] == None %}
@@ -156,7 +164,14 @@ All tests passed!
 All tests passed!
 ```
 {%- else -%}
-```
+
+<div style="height: 400px; overflow-y: scroll; padding: 0px;">
+
+```{code-block}
+:linenos:
+
 {{ wf["formatting"] }}
 ```
+</div >
+
 {% endif %}

--- a/source/_templates/workflow_page.md
+++ b/source/_templates/workflow_page.md
@@ -32,13 +32,13 @@
 {% if wf["linting"] == None -%}
     {bdg-success}`linting: passed`
 {%- else -%}
-    {bdg-ref-danger}`linting: failed <linting-{{ wf["full_name"] }}>`
+    {bdg-ref-danger}`linting: failed <linting-{{ wf["full_name"]|slugify }}>`
 {%- endif -%},
 **Formatting:**
 {% if wf["formatting"] == None -%}
     {bdg-success}`formatting: passed`
 {%- else -%}
-    {bdg-ref-danger}`formatting: failed <formatting-{{ wf["full_name"] }}>`
+    {bdg-ref-danger}`formatting: failed <formatting-{{ wf["full_name"]|slugify }}>`
 {%- endif %}
 
 ## Deployment
@@ -136,7 +136,7 @@ _The following section is imported from the workflow's `config/README.md`_.
 
 ## Linting and formatting
 
-(linting-{{ wf["full_name"] }})=
+(linting-{{ wf["full_name"]|slugify }})=
 ### Linting results
 
 {% if wf["linting"] == None %}
@@ -156,7 +156,7 @@ All tests passed!
 
 {% endif %}
 
-(formatting-{{ wf["full_name"] }})=
+(formatting-{{ wf["full_name"]|slugify }})=
 ### Formatting results
 
 {% if wf["formatting"] == None %}

--- a/source/build_wf_pages.py
+++ b/source/build_wf_pages.py
@@ -26,13 +26,13 @@ def check_deployment(depl):
     return result
 
 
-def check_qc_output(qc_item):
+def check_qc_output(qc_item, max_lines = 200):
     if qc_item is None:
         return None
     else:
         result = qc_item.split("\n")
-        if len(result) > 20:
-            return "\n".join(result[:20]) + "\n\n... (truncated)"
+        if len(result) > max_lines:
+            return "\n".join(result[:max_lines]) + "\n\n... (truncated)"
         else:
             return "\n".join(result)
 

--- a/source/build_wf_pages.py
+++ b/source/build_wf_pages.py
@@ -1,4 +1,5 @@
 import json
+import re
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from datetime import datetime
 from pathlib import Path
@@ -26,7 +27,7 @@ def check_deployment(depl):
     return result
 
 
-def check_qc_output(qc_item, max_lines = 200):
+def check_qc_output(qc_item, max_lines=200):
     if qc_item is None:
         return None
     else:
@@ -37,6 +38,13 @@ def check_qc_output(qc_item, max_lines = 200):
             return "\n".join(result)
 
 
+def slugify(value):
+    value = value.lower()
+    value = re.sub(r"[^a-z0-9]+", "-", value)
+    value = value.strip("-")
+    return value
+
+
 def build_wf_pages():
     # import jinja templates
     env = Environment(
@@ -45,6 +53,7 @@ def build_wf_pages():
         trim_blocks=True,
         lstrip_blocks=True,
     )
+    env.filters["slugify"] = slugify
     template = env.get_template("workflow_page.md")
 
     # import workflow data

--- a/source/build_wf_tables.py
+++ b/source/build_wf_tables.py
@@ -1,4 +1,5 @@
 import json
+import re
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from datetime import datetime
 from pathlib import Path
@@ -13,6 +14,13 @@ def clean_repo(repo):
     else:
         repo["description"] = "No description available."
     return repo
+
+
+def slugify(value):
+    value = value.lower()
+    value = re.sub(r"[^a-z0-9]+", "-", value)
+    value = value.strip("-")
+    return value
 
 
 # function to render markdown tables and cards
@@ -90,6 +98,7 @@ def build_wf_tables():
         trim_blocks=True,
         lstrip_blocks=True,
     )
+    env.filters["slugify"] = slugify
 
     # render tables
     for wf_type in ["standardized", "other"]:

--- a/source/conf.py
+++ b/source/conf.py
@@ -58,6 +58,7 @@ pygments_style = "sphinx"
 html_permalinks_icon = Icons.permalinks_icon
 suppress_warnings = ["myst.xref_missing", "myst.header"]
 myst_enable_extensions = ["colon_fence", "attrs_block"]
+myst_heading_anchors = 2
 html_sidebars = {
     "**": ["globaltoc.html"],
 }


### PR DESCRIPTION
- linting and formatting were previous confined to a 20 lines code block
- now we have more space to show linting/formatting results with scrollable code blocks
- cross references added to go from tables and workflow page top to the lint/format section
- updated 1 README badge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated deployment workflow badge and link in the README.
  - Enhanced workflow documentation by adding clickable reference links to failed linting and formatting badges.
  - Improved workflow page readability with scrollable containers and line numbers for failed linting/formatting outputs.
  - Enabled automatic heading anchors for Markdown headings up to level 2 in the documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->