### PR TITLE
fix: correct typos and remove lint warnings.

### DIFF
--- a/scripts/cleanup-catalog.py
+++ b/scripts/cleanup-catalog.py
@@ -3,7 +3,9 @@ import math
 import os
 import time
 
-from common import store_data, check_repo_exists, g, previous_repos, previous_skips, offset
+from common import (store_data, check_repo_exists, g,
+                    previous_repos, previous_skips, offset)
+
 
 def cleanup(repos):
     _offset = int(offset / 100 * len(repos))
@@ -12,13 +14,14 @@ def cleanup(repos):
     for i, repo_name in enumerate(list(repos.keys())[_offset:min(_offset + n, len(repos))]):
         if i != 0:
             time.sleep(5)
-        
+
         if not check_repo_exists(g, repo_name):
             logging.info(f"Repo {repo_name} has been deleted or moved")
             del repos[repo_name]
             continue
-        else:
-            logging.info(f"Repo {repo_name} still exists, keeping data.")
+
+        logging.info(f"Repo {repo_name} still exists, keeping data.")
+
 
 logging.info("Remove superfluous repos.")
 cleanup(previous_repos)

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -8,7 +8,6 @@ import time
 from ratelimit import limits, sleep_and_retry
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from github import Github
-from github.ContentFile import ContentFile
 from github.GithubException import UnknownObjectException, RateLimitExceededException
 
 logging.basicConfig(level=logging.INFO)

--- a/scripts/generate-catalog.py
+++ b/scripts/generate-catalog.py
@@ -191,10 +191,12 @@ for i in range(offset, end):
             # download release tag (use hardcoded url, because repo.tarball_url can sometimes
             # cause ambiguity errors if a branch is called the same as the release).
             tarball_url = f"https://github.com/{repo.full_name}/tarball/refs/tags/{release.tag_name}"
+
             def get_tarfile():
                 return tarfile.open(
                     fileobj=urllib.request.urlopen(tarball_url), mode="r|gz"
                 )
+
             root_dir = get_tarfile().getmembers()[0].name
             get_tarfile().extractall(path=tmp, filter="tar")
             tmp /= root_dir
@@ -301,7 +303,7 @@ for i in range(offset, end):
     )
     logging.info(
         f"Repo {repo_obj.full_name} processed successfully as "
-        f"{'standardized' if repo_obj.standardized else 'non-standardized'} workflow. "
+        f"{'standardized' if repo_obj.standardized else 'non-standardized'} workflow."
     )
 
     repos.append(

--- a/source/conf.py
+++ b/source/conf.py
@@ -7,7 +7,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "snakemake-workflow-catalog"
-copyright = "2025, The Snakemake team. "
+copyright = "2025, The Snakemake team."
 author = "Johannes Koester, Michael Jahn"
 
 import sys
@@ -53,7 +53,7 @@ html_theme_options = {
         "Snakemake documentation": "https://snakemake.readthedocs.io",
     },
 }
-html_title = "Snakemake worklow catalog"
+html_title = "Snakemake workflow catalog"
 pygments_style = "sphinx"
 html_permalinks_icon = Icons.permalinks_icon
 suppress_warnings = ["myst.xref_missing", "myst.header"]

--- a/source/docs/about/adding_workflows.md
+++ b/source/docs/about/adding_workflows.md
@@ -39,7 +39,7 @@ Definition of mandatory flags can happen through a list of strings (`['--a', '--
 :::
 
 :::{note}
-The content of the `.snakemake-workflow-catalog.yml` file is subject to change. Flags might change in the near future, but current versions will always stay compatible with the catalog. 
+The content of the `.snakemake-workflow-catalog.yml` file is subject to change. Flags might change in the near future, but current versions will always stay compatible with the catalog.
 :::
 
 Once included in the standardized usage area you can link directly to the workflow page using the URL `https://snakemake.github.io/snakemake-workflow-catalog/docs/workflows/<owner>/<repo>`. Do not forget to replace the `<owner>` and `<repo>` tags at the end of the URL.

--- a/source/docs/snakemake.md
+++ b/source/docs/snakemake.md
@@ -19,7 +19,7 @@ The Snakemake workflow management system is a tool to create reproducible and sc
 
 The best starting point to create your own workflows is the [Snakemake workflow template](https://github.com/snakemake-workflows/snakemake-workflow-template).
 
-The template comes with a pre-configured structure that is compatible with the Snakemake catalog ['standardized usage'](<about/adding_workflows>). Just fork or clone the template, start addiong rules and push your workflow to Github. The structure of 'standardized' workflows is like this:
+The template comes with a pre-configured structure that is compatible with the Snakemake catalog ['standardized usage'](<about/adding_workflows>). Just fork or clone the template, start adding rules and push your workflow to Github. The structure of 'standardized' workflows is like this:
 
 ```
 ├── config/

--- a/source/index.md
+++ b/source/index.md
@@ -68,6 +68,6 @@ Explore workflows 🔭
 ## Contributing
 
 - Improving PRs or issues with the workflow catalog (only the catalog, not the workflows themselves) can be made [here](http://github.com/snakemake/snakemake-workflow-catalog)
-- Improving PRs or issues with the listed workflows can be made at the respective workflow repository (see indivuidual [workflow pages](<docs/all_standardized_workflows>)).
-- Resources for creating new workflows can be found [here](<docs/snakemake>) or in more detail on the [Snakemake documnentation](https://snakemake.readthedocs.io/en/stable/index.html)
+- Improving PRs or issues with the listed workflows can be made at the respective workflow repository (see individual [workflow pages](<docs/all_standardized_workflows>)).
+- Resources for creating new workflows can be found [here](<docs/snakemake>) or in more detail on the [Snakemake documentation](https://snakemake.readthedocs.io/en/stable/index.html)
 - New workflows will be [automatically added](<docs/catalog>) to the workflow catalog if they are contained in eligible Github repositories


### PR DESCRIPTION
I've fixed typos and removed lint warnings that are inconsistent with the current code conventions.

* ~Makefile: Replace all tabs with four spaces.~ Reverted
* scripts/cleanup-catalog.py: Split long import line; simplify if-else using continue condition; add a newline at end of file.
* scripts/common.py: Remove unused import
* scripts/generate-catalog.py: Add new lines around the inline func definition; remove a trailing space in string.
* source/conf.py: Remove a trailing space; fix a typo.
* source/docs/about/adding_workflows.md: Remove a trailing.
* source/docs/snakemake.md: Fix typos.
* source/index.md: Fix typos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed multiple typographical errors and removed trailing spaces across various documentation pages to improve clarity and professionalism.
  * Corrected a typo in the HTML title configuration for the documentation site.

* **Style**
  * Reformatted import statements and adjusted blank lines in scripts to enhance code readability.
  * Simplified control flow in a script by reorganizing logging statements without affecting functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->