### PR TITLE
fix: separate generate and cleanup actions

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -35,7 +35,7 @@ jobs:
           git commit -m "Add changes" -a || echo "No changes to commit"
 
       - name: Push changes
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,13 +1,11 @@
-name: Generate catalog
+name: Cleanup catalog
 
 on:
   schedule:
-    - cron: 0 5 * * 1
-  push:
-    branches: [main]
+    - cron: 0 7 1 * *
 
 jobs:
-  generate-catalog:
+  cleanup-catalog:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -24,12 +22,11 @@ jobs:
         run: |
           git pull --rebase origin ${{ github.ref }}
 
-      - name: generate-catalog
+      - name: cleanup-catalog
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OFFSET: ${{ matrix.offset }}
-          LATEST_COMMIT: 7
-        run: pixi run generate-catalog
+        run: pixi run cleanup-catalog
 
       - name: Commit files
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
     types:
       - completed
   push:
-    branches: [main, dev]
+    branches: [main]
 
 defaults:
   run:

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   generate-catalog:
+    if: github.event_name == 'schedule' || github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -38,7 +39,7 @@ jobs:
           git commit -m "Add changes" -a || echo "No changes to commit"
 
       - name: Push changes
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   pull_request:
-    branches: [main, dev]
+    branches: [main]
 
 jobs:
   generate-catalog:


### PR DESCRIPTION
closes #77 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD workflows now target the main branch for pushes and PRs, streamlining deploys and tests.
  * Added a monthly scheduled maintenance task to run catalog cleanup.
  * Removed automated cleanup from the catalog generation workflow and consolidated it into the new scheduled task.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->