### PR TITLE
Update lockfile during generation

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -21,6 +21,12 @@ jobs:
         with:
           cache: true
 
+      - name: Upload lockfile
+        uses: actions/upload-artifact@v7
+        with:
+          name: pixi_lock.zip
+          path: ./pixi.lock
+
       - name: Pull latest changes
         run: |
           git pull --rebase origin ${{ github.ref }}

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@v0
         with:
           cache: true
+          locked: false
 
       - name: Upload lockfile
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
To ensure the latest Snakemake version matching the constraints in `pixi.toml` is used, the generate action will not rely on the lockfile when creating the Pixi env. To still be able to reproduce the environment locally, the updated lockfile will be uploaded as a workflow artifact.

> Note that the updating of packages naturally is not limited to just Snakemake.

Closes #80.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to enhance build process management and artifact handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->