### PR TITLE
ci(generate): Initially update & commit pixi.lock

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -7,8 +7,33 @@ on:
     branches: [main]
 
 jobs:
-  generate-catalog:
+  update-lockfile:
     if: github.event_name == 'schedule' || github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: prefix-dev/setup-pixi@v0
+        with:
+          cache: true
+
+      - name: Update pixi.lock
+        run: pixi update
+
+      - name: Commit updated lockfile
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git commit -m "Update pixi.lock" pixi.lock || echo "No changes to commit"
+
+      - name: Push changes
+        uses: ad-m/github-push-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
+
+  generate-catalog:
+    needs: update-lockfile
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
This way the lockfile is automatically updated before every report generation, ensuring an up-to-date software env that can be reproduced locally.

> Note: Contents of this PR have been generated by Coding Agents (Github Copilot using Claude Sonnet 4.6). Nonetheless I have read and stand behind every line of code submitted here.

Since this will also update the Pixi lockfile version in its first commit, as can be seen as part of the [test on our fork](https://github.com/TRON-Bioinformatics/snakemake-workflow-catalog/commit/9434d1f711ac1d9dce55cefd1b7cb40644f86afb), I would suggest merging #81 first, as that pre-empts the update in a more graceful way (IMO).

Closes #80.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release workflow so the lockfile is updated and committed automatically before catalog generation.
  * Made catalog generation run after the lockfile update step, reducing the chance of stale or inconsistent output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->